### PR TITLE
fix(vite-plugin): add missing virtual type exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,8 +22,8 @@ module.exports = {
       files: ['*.ts', '*.tsx', '*.mts'],
       parserOptions: {
         project: [
-          path.resolve(__dirname, './packages/*/tsconfig.json'),
-          path.resolve(__dirname, './packages/examples/*/tsconfig.json'),
+          path.resolve(__dirname, './packages/**/tsconfig.json'),
+          path.resolve(__dirname, './packages/examples/**/tsconfig.json'),
         ],
       },
     },

--- a/packages/examples/react/tsconfig.json
+++ b/packages/examples/react/tsconfig.json
@@ -4,6 +4,6 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
-    "types": ["node", "react", "react-dom", "@storylite/vite-plugin/dist/virtual-modules.d.ts"]
+    "types": ["node", "react", "react-dom", "@storylite/vite-plugin/virtual"]
   }
 }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -9,10 +9,23 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.cjs"
+    },
+    "./virtual": {
+      "types": "./dist/virtual-modules.d.ts"
     }
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/index.d.ts"
+      ],
+      "virtual": [
+        "dist/virtual-modules.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
- add missing virtual type exports to package.json
- fix tsconfig.json types in react examples

closes #27

---

In order to run eslint on windows 11 I had to change the project paths asterisk to double asterisk. I hope this has no effect on other systems.