### PR TITLE
fix(ui): fix and improve svg styles

### DIFF
--- a/packages/storylite/src/styles/base.css
+++ b/packages/storylite/src/styles/base.css
@@ -75,6 +75,6 @@
 }
 
 .storylite-inlinehtml {
-  display: inline-block;
+  display: inline-flex;
   vertical-align: middle;
 }

--- a/packages/storylite/src/styles/components/btn.css
+++ b/packages/storylite/src/styles/components/btn.css
@@ -19,11 +19,17 @@ a.storylite-btn {
   padding: 0.4rem 0.4rem;
 }
 
-.storylite-btn svg {
+/** All toolbar addon icons */
+:where(.storylite-btn span) svg {
   width: max(1rem, 16px);
   height: max(1rem, 16px);
-  display: inline-block;
   vertical-align: middle;
+}
+
+/** Custom toolbar addon icons (right side) */
+:where(.storylite-btn) span:not(.storylite-inlinehtml) {
+  display: inline-flex;
+  line-height: 16px;
 }
 
 :where(.storylite-btn--hoverable).storylite-btn:hover,

--- a/packages/storylite/src/styles/components/sidebar.css
+++ b/packages/storylite/src/styles/components/sidebar.css
@@ -98,7 +98,8 @@
   font-size: 0.8rem;
   line-height: 1rem;
   color: inherit;
-  display: flex;
+  display: inline-flex;
+  align-items: center;
   text-decoration: none;
   transition: background-color 0.2s linear;
   cursor: pointer;
@@ -119,6 +120,7 @@
 }
 
 .storylite-sidebar-nav .storylite-navbtn .storylite-icon {
+  line-height: 12px;
   margin-right: 5px;
 }
 


### PR DESCRIPTION
There is a disparity in the spacing of the sidebar icon/label and the toolbar icon groups for default addons, custom addons and emojis. Also The `flex` model for buttons looks kind of broken.

![issue-storylite](https://github.com/itsjavi/storylite/assets/45284565/9ef21ce4-c57a-4052-ab6e-6bbd0945200a)

![Screenshot 2023-09-06 224101](https://github.com/itsjavi/storylite/assets/45284565/4643a522-74fb-4153-834c-148ce2300c25)

I made a checkout to [ce89a66] to check if the issue exist before we started working on the icons.
It does, but with the icon refactor, the spacing gets more offset.

This PR fixes the issues, for both sidebar, toolbar custom icons and emojis and flex model.