### PR TITLE
fix(ui): fix sidebar menu items too small

### DIFF
--- a/packages/storylite/src/styles/components/sidebar.css
+++ b/packages/storylite/src/styles/components/sidebar.css
@@ -94,9 +94,9 @@
 .storylite-sidebar-nav .storylite-navbtn {
   all: unset;
   appearance: none;
-  padding: 0.5rem 1rem;
+  padding: 0.46rem 1rem;
   font-size: 0.8rem;
-  line-height: 1rem;
+  line-height: 1.1rem;
   color: inherit;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
closes #68 

![2023-09-20_14h48_13](https://github.com/itsjavi/storylite/assets/45284565/729d4c82-e7e4-4666-bc98-382b13ff84af)
