### PR TITLE
fix: side effects css leaked into manager UI

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build packages
+        run: pnpm build:packages
+
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v5

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -48,3 +48,69 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  e2e:
+    name: Playwright E2E
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          show-progress: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key:
+            ${{ runner.os }}-playwright-${{ hashFiles('apps/e2e/package.json', 'pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Chromium
+        run: pnpm -F @storylite/e2e exec playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: pnpm -F @storylite/e2e run e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: playwright-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            apps/e2e/playwright-report
+            apps/e2e/test-results
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Publish Playwright summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo "### Playwright E2E"
+            echo ""
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| Workflow run | [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) |"
+            echo "| Browser cache | ${{ steps.playwright-cache.outputs.cache-hit == 'true' && 'hit' || 'miss' }} |"
+            echo "| Report artifact | playwright-report-${{ github.run_id }}-${{ github.run_attempt }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for taking the time to contribute.
 ## Requirements
 
 - Node.js 24 or newer.
-- pnpm 11.2.2. The exact version is recorded in `package.json`.
+- pnpm 11 or greater. The exact version is recorded in `package.json`.
 
 Install dependencies from the repository root:
 
@@ -73,6 +73,61 @@ Run package-specific scripts with pnpm filters when you only need one workspace:
 pnpm -F @storylite/web run test
 pnpm -F @storylite/storylite run typecheck
 ```
+
+## Testing Local Package Changes in Consumer Projects
+
+Use packed tarballs when you need someone to test a branch in their own app before publishing a
+StoryLite release. This is closer to the published package shape than `pnpm link` because it uses
+the same `files`, `bin`, `exports`, and built `dist` output that npm receives.
+
+From this repository:
+
+```sh
+pnpm install
+pnpm build:packages
+
+rm -rf /tmp/storylite-local-packages
+mkdir -p /tmp/storylite-local-packages
+
+for package in contracts preview-host storylite renderer-react; do
+  (cd "packages/$package" && pnpm pack --pack-destination /tmp/storylite-local-packages)
+done
+```
+
+Pack `renderer-preact`, `renderer-svelte`, `renderer-vue`, or `renderer-solid` instead of
+`renderer-react` when the consumer app uses one of those adapters.
+
+In the consumer project, install the tarballs and force StoryLite transitive dependencies to the
+same local build. Use absolute `file:` paths. The `<version>` placeholder in this example is the
+current version from each package's `package.json`:
+
+```yaml
+# pnpm-workspace.yaml
+overrides:
+  '@storylite/contracts': file:/tmp/storylite-local-packages/storylite-contracts-<version>.tgz
+  '@storylite/preview-host': file:/tmp/storylite-local-packages/storylite-preview-host-<version>.tgz
+  '@storylite/storylite': file:/tmp/storylite-local-packages/storylite-storylite-<version>.tgz
+  '@storylite/renderer-react': file:/tmp/storylite-local-packages/storylite-renderer-react-<version>.tgz
+```
+
+Then install and run the consumer project's normal StoryLite commands:
+
+```sh
+pnpm install --force
+pnpm storylite
+pnpm storylite:build
+```
+
+If the consumer app does not already depend on the renderer adapter, add the same tarball as a dev
+dependency:
+
+```sh
+pnpm add -D file:/tmp/storylite-local-packages/storylite-renderer-react-<version>.tgz
+```
+
+After changing this repository again, rebuild and repack the tarballs, then rerun
+`pnpm install --force` in the consumer project so pnpm refreshes packages with the same version
+number.
 
 ## Publishing
 

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -13,7 +13,7 @@
     "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.60.0",
     "@types/node": "^25.9.1",
-    "@vitest/browser-playwright": "^4.1.7",
+    "@vitest/browser-playwright": "^4.1.8",
     "typescript": "^6.0.3"
   }
 }

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -45,7 +45,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? 'github' : [['list'], ['html', { open: 'never' }]],
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
   timeout: 30_000,
   expect: { timeout: 5_000 },
   use: {

--- a/apps/e2e/tests/apps/web/canvas.spec.ts
+++ b/apps/e2e/tests/apps/web/canvas.spec.ts
@@ -8,5 +8,5 @@ test('standalone canvas route renders only the selected story preview', async ({
   await expect(page.getByLabel('Standalone story preview')).toBeVisible()
   await expect(page.getByRole('complementary', { name: 'Stories' })).toHaveCount(0)
   await expect(page.getByRole('complementary', { name: 'Story controls' })).toHaveCount(0)
-  await expect(page.getByRole('button', { name: 'Save changes' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Run storylite build' })).toBeVisible()
 })

--- a/apps/e2e/tests/apps/web/landing.spec.ts
+++ b/apps/e2e/tests/apps/web/landing.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from './fixtures.ts'
-import { expectHomeReady, openStory } from './test-utils.ts'
+import { expectHomeReady, expandPureCssStories, openStory } from './test-utils.ts'
 import { expectHash, expectNoPageOverflow } from '../../shared/test-utils.ts'
 
 test('home page renders StoryLite project information and sidebar stories', async ({ page }) => {
@@ -17,7 +17,8 @@ test('home page renders StoryLite project information and sidebar stories', asyn
   await expectHomeReady(page)
   const sidebar = page.getByRole('complementary', { name: 'Stories' })
   await expect(sidebar.getByText('Component Stories', { exact: true })).toBeVisible()
-  await expect(sidebar.getByRole('button', { name: /CSS Demos/ })).toBeVisible()
+  await expect(sidebar.getByRole('button', { name: /^Examples\b/ })).toBeVisible()
+  await expandPureCssStories(page)
   for (const story of ['Button', 'Card', 'Field', 'Badge', 'Layout']) {
     await expect(sidebar.getByRole('link', { name: story, exact: true })).toBeVisible()
   }

--- a/apps/e2e/tests/apps/web/static-noscript.spec.ts
+++ b/apps/e2e/tests/apps/web/static-noscript.spec.ts
@@ -11,7 +11,8 @@ test('static build sidebar links open materialized story pages without JavaScrip
   const sidebar = page.getByRole('complementary', { name: 'Stories' })
   await expect(sidebar).toBeVisible()
   await expect(sidebar.getByText('Component Stories', { exact: true })).toBeVisible()
-  await expect(sidebar.getByRole('button', { name: /CSS Demos/ })).toBeVisible()
+  await expect(sidebar.getByRole('button', { name: /^Examples\b/ })).toBeVisible()
+  await expect(sidebar.getByRole('button', { name: /^Pure CSS\b/ })).toBeVisible()
 
   const buttonStory = sidebar.getByRole('link', { name: 'Button', exact: true })
   await expect(buttonStory).toBeVisible()

--- a/apps/e2e/tests/apps/web/test-utils.ts
+++ b/apps/e2e/tests/apps/web/test-utils.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 
 import { expectHash, expectRouteDocumentReady } from '../../shared/test-utils.ts'
@@ -17,6 +17,7 @@ export async function openStory(
   storyButtonName: string,
   storyId: string,
 ): Promise<void> {
+  await expandPureCssStories(page)
   await page.getByRole('link', { name: storyButtonName, exact: true }).click()
   await expectHash(page).toBe(`#/story/${storyId}`)
   await expect(page.locator(PREVIEW_IFRAME)).toBeVisible()
@@ -27,4 +28,19 @@ export async function expectStoryShell(page: Page, storyName: string): Promise<v
   await expect(page.getByRole('region', { name: 'Preview workspace' })).toBeVisible()
   await expect(page.getByRole('complementary', { name: 'Story controls' })).toBeVisible()
   await expect(page.locator('.inspector__header strong')).toHaveText(storyName)
+}
+
+export async function expandPureCssStories(page: Page): Promise<void> {
+  const sidebar = page.getByRole('complementary', { name: 'Stories' })
+
+  await expandSection(sidebar.getByRole('button', { name: /^Examples\b/ }))
+  await expandSection(sidebar.getByRole('button', { name: /^Pure CSS\b/ }))
+}
+
+async function expandSection(button: Locator): Promise<void> {
+  await expect(button).toBeVisible()
+
+  if ((await button.getAttribute('aria-expanded')) !== 'true') {
+    await button.click()
+  }
 }

--- a/apps/e2e/tests/apps/web/toolbar.spec.ts
+++ b/apps/e2e/tests/apps/web/toolbar.spec.ts
@@ -10,29 +10,21 @@ test('viewport selector resizes the canvas frame', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Choose viewport' }).click()
   await page.getByLabel('Viewports').getByRole('button').filter({ hasText: 'Mobile' }).click()
-  await expect(canvasFrame).toHaveCSS('width', '360px')
+  await expect(canvasFrame).toHaveCSS('width', '390px')
 
   await page.getByRole('button', { name: 'Choose viewport' }).click()
   await page.getByLabel('Viewports').getByRole('button').filter({ hasText: 'Desktop' }).click()
-  await expect(canvasFrame).toHaveCSS('width', '1280px')
+  await expect(canvasFrame).toHaveCSS('width', '1120px')
 })
 
-test('preview theme and custom toolbar controls update the iframe body', async ({ page }) => {
+test('preview theme control updates the iframe document', async ({ page }) => {
   await page.goto('/#/story/basic--button')
   await expectStoryShell(page, 'Button')
 
   const frame = page.frameLocator(PREVIEW_IFRAME)
-  const body = frame.locator('body')
 
   await page.getByRole('button', { name: 'Use dark theme' }).click()
   await expect(frame.locator('html')).toHaveAttribute('data-theme', 'dark')
-
-  await page.getByRole('button', { name: 'A11y outlines' }).click()
-  await expect(body).toHaveClass(/show-a11y-outlines/)
-
-  await page.getByRole('button', { name: 'Density' }).click()
-  await page.getByLabel('Density').getByRole('button', { name: 'Compact' }).click()
-  await expect(body).toHaveClass(/density-compact/)
 })
 
 test('background selector applies the selected preview background', async ({ page }) => {
@@ -40,13 +32,12 @@ test('background selector applies the selected preview background', async ({ pag
   await expectStoryShell(page, 'Card')
 
   await page.getByRole('button', { name: 'Choose canvas background' }).click()
-  await page.getByLabel('Canvas backgrounds').getByRole('button', { name: 'Mint' }).click()
+  await page.getByLabel('Canvas backgrounds').getByRole('button', { name: 'Dark' }).click()
 
-  const background = await page
-    .frameLocator(PREVIEW_IFRAME)
-    .locator('body')
-    .evaluate((body) => body.style.background)
-  expect(background).toBe('rgb(236, 253, 245)')
+  await expect(page.frameLocator(PREVIEW_IFRAME).locator('body')).toHaveCSS(
+    'background-color',
+    'rgb(17, 17, 17)',
+  )
 })
 
 test('workspace can be maximized and restored', async ({ page }) => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@types/node": "^25.9.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.8"
   }
 }

--- a/demos/storylite-html/package.json
+++ b/demos/storylite-html/package.json
@@ -15,6 +15,6 @@
   },
   "devDependencies": {
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.8"
   }
 }

--- a/demos/storylite-html/src/components/basic.stories.ts
+++ b/demos/storylite-html/src/components/basic.stories.ts
@@ -8,6 +8,7 @@ import badgeHtml from './badge.html?raw'
 import buttonHtml from './button.html?raw'
 import cardHtml from './card.html?raw'
 import fieldHtml from './field.html?raw'
+import { renderImportedCssDemo } from './imported-css-demo'
 import layoutHtml from './layout.html?raw'
 import css from '../styles.css?raw'
 
@@ -39,6 +40,11 @@ type LayoutArgs = {
   first: string
   second: string
   third: string
+}
+
+type ImportedCssArgs = {
+  label: string
+  detail: string
 }
 
 const parameters: StoryLiteParameters = { css }
@@ -97,6 +103,15 @@ export const Layout = {
   },
   render: template(layoutHtml),
 } satisfies StoryLiteStoryDefinition<LayoutArgs>
+
+export const ImportedCss = {
+  name: 'Imported CSS',
+  args: {
+    label: 'Side-effect CSS import',
+    detail: 'This card is styled by CSS imported from its helper module.',
+  },
+  render: renderImportedCssDemo,
+} satisfies StoryLiteStoryDefinition<ImportedCssArgs>
 
 function template<TArgs extends TemplateArgs>(html: string) {
   return ((args: TArgs) =>

--- a/demos/storylite-html/src/components/imported-css-demo.css
+++ b/demos/storylite-html/src/components/imported-css-demo.css
@@ -1,0 +1,22 @@
+.imported-css-demo {
+  display: grid;
+  gap: 8px;
+  max-inline-size: 440px;
+  padding: 18px;
+  border: 2px solid oklch(58% 0.16 150);
+  border-radius: 10px;
+  background: oklch(95% 0.05 150);
+  color: oklch(25% 0.05 155);
+}
+
+.imported-css-demo strong {
+  font-size: 1.1rem;
+}
+
+.imported-css-demo p {
+  margin: 0;
+}
+
+.brand__content {
+  background: oklch(58% 0.16 150);
+}

--- a/demos/storylite-html/src/components/imported-css-demo.ts
+++ b/demos/storylite-html/src/components/imported-css-demo.ts
@@ -1,0 +1,22 @@
+import './imported-css-demo.css'
+
+type ImportedCssDemoArgs = {
+  readonly label: string
+  readonly detail: string
+}
+
+export function renderImportedCssDemo(args: ImportedCssDemoArgs): string {
+  return `<article class="imported-css-demo">
+    <strong>${escapeHtml(args.label)}</strong>
+    <p>${escapeHtml(args.detail)}</p>
+  </article>`
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}

--- a/demos/storylite-html/src/smoke.test.ts
+++ b/demos/storylite-html/src/smoke.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { Button, Card, Field } from './components/basic.stories'
+import { Button, Card, Field, ImportedCss } from './components/basic.stories'
 import { Button as WebComponentButton, Meter } from './components/elements.stories'
 
 describe('storylite-html demo', () => {
@@ -7,6 +7,7 @@ describe('storylite-html demo', () => {
     expect(Button.render?.(Button.args ?? {})).toContain('demo-btn')
     expect(Card.render?.(Card.args ?? {})).toContain('demo-card')
     expect(Field.render?.(Field.args ?? {})).toContain('demo-field')
+    expect(ImportedCss.render?.(ImportedCss.args ?? {})).toContain('imported-css-demo')
   })
 
   it('exports light-DOM web component stories', () => {

--- a/demos/storylite-html/src/storylite-env.d.ts
+++ b/demos/storylite-html/src/storylite-env.d.ts
@@ -2,3 +2,5 @@ declare module '*?raw' {
   const source: string
   export default source
 }
+
+declare module '*.css'

--- a/demos/storylite-preact/package.json
+++ b/demos/storylite-preact/package.json
@@ -21,6 +21,6 @@
     "@tailwindcss/vite": "^4.3.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.8"
   }
 }

--- a/demos/storylite-react/package.json
+++ b/demos/storylite-react/package.json
@@ -13,15 +13,15 @@
   "dependencies": {
     "@storylite/renderer-react": "workspace:*",
     "@storylite/storylite": "workspace:*",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.0",
-    "@types/react": "^19.2.15",
+    "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.8"
   }
 }

--- a/demos/storylite-react/src/components/ReactImportedCssCard.css
+++ b/demos/storylite-react/src/components/ReactImportedCssCard.css
@@ -1,0 +1,22 @@
+.react-imported-css-card {
+  display: grid;
+  gap: 8px;
+  max-inline-size: 460px;
+  padding: 18px;
+  border: 2px solid oklch(58% 0.16 250);
+  border-radius: var(--react-radius);
+  background: oklch(95% 0.04 250);
+  color: oklch(25% 0.06 255);
+}
+
+.react-imported-css-card strong {
+  font-size: 1.1rem;
+}
+
+.react-imported-css-card p {
+  margin: 0;
+}
+
+.brand__content {
+  background: oklch(58% 0.16 250);
+}

--- a/demos/storylite-react/src/components/ReactImportedCssCard.tsx
+++ b/demos/storylite-react/src/components/ReactImportedCssCard.tsx
@@ -1,0 +1,15 @@
+import './ReactImportedCssCard.css'
+
+export type ReactImportedCssCardProps = {
+  readonly label: string
+  readonly detail: string
+}
+
+export function ReactImportedCssCard({ label, detail }: ReactImportedCssCardProps) {
+  return (
+    <article className="react-imported-css-card">
+      <strong>{label}</strong>
+      <p>{detail}</p>
+    </article>
+  )
+}

--- a/demos/storylite-react/src/components/react.stories.tsx
+++ b/demos/storylite-react/src/components/react.stories.tsx
@@ -6,6 +6,7 @@ import type {
 import { ReactButton } from './ReactButton'
 import { ReactCard } from './ReactCard'
 import { ReactField } from './ReactField'
+import { ReactImportedCssCard } from './ReactImportedCssCard'
 import { ReactLayout } from './ReactLayout'
 
 type ButtonArgs = {
@@ -29,6 +30,11 @@ type LayoutArgs = {
   first: string
   second: string
   third: string
+}
+
+type ImportedCssArgs = {
+  label: string
+  detail: string
 }
 
 const parameters: StoryLiteParameters = {
@@ -81,3 +87,12 @@ export const Layout = {
   },
   render: (args) => <ReactLayout first={args.first} second={args.second} third={args.third} />,
 } satisfies StoryLiteStoryDefinition<LayoutArgs>
+
+export const ImportedCss = {
+  name: 'Imported CSS',
+  args: {
+    label: 'Side-effect CSS import',
+    detail: 'This card is styled by CSS imported inside the React component.',
+  },
+  render: (args) => <ReactImportedCssCard label={args.label} detail={args.detail} />,
+} satisfies StoryLiteStoryDefinition<ImportedCssArgs>

--- a/demos/storylite-react/src/smoke.test.tsx
+++ b/demos/storylite-react/src/smoke.test.tsx
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import meta, { Button, Card, Layout } from './components/react.stories'
+import meta, { Button, Card, ImportedCss, Layout } from './components/react.stories'
 
 describe('storylite-react demo', () => {
   it('exports React stories', () => {
     expect(meta.parameters?.renderer).toBe('react')
     expect(Button.render).toBeTypeOf('function')
     expect(Card.render).toBeTypeOf('function')
+    expect(ImportedCss.render).toBeTypeOf('function')
     expect(Layout.render).toBeTypeOf('function')
   })
 })

--- a/demos/storylite-react/src/storylite-env.d.ts
+++ b/demos/storylite-react/src/storylite-env.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css'

--- a/demos/storylite-solid/package.json
+++ b/demos/storylite-solid/package.json
@@ -20,6 +20,6 @@
     "@tailwindcss/vite": "^4.3.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.8"
   }
 }

--- a/demos/storylite-svelte/package.json
+++ b/demos/storylite-svelte/package.json
@@ -13,14 +13,14 @@
   "dependencies": {
     "@storylite/renderer-svelte": "workspace:*",
     "@storylite/storylite": "workspace:*",
-    "svelte": "^5.56.0"
+    "svelte": "^5.56.1"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tailwindcss/vite": "^4.3.0",
-    "svelte-check": "^4.4.8",
+    "svelte-check": "^4.5.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.8"
   }
 }

--- a/demos/storylite-vue/package.json
+++ b/demos/storylite-vue/package.json
@@ -21,6 +21,6 @@
     "@tailwindcss/vite": "^4.3.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "pkg:version": "node ./scripts/pkg-version.mjs"
   },
   "devDependencies": {
-    "oxfmt": "^0.52.0",
+    "oxfmt": "^0.53.0",
     "publint": "^0.3.21",
     "tsdown": "^0.22.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.8"
   },
   "engines": {
     "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -45,5 +45,5 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@11.5.0"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -50,10 +50,10 @@
     "@storylite/contracts": "workspace:*"
   },
   "devDependencies": {
-    "@types/react": "^19.2.15",
+    "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
-    "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "peerDependencies": {
     "react": "^19.2.1",

--- a/packages/renderer-svelte/package.json
+++ b/packages/renderer-svelte/package.json
@@ -51,7 +51,7 @@
     "@sveltejs/vite-plugin-svelte": "^7.1.2"
   },
   "devDependencies": {
-    "svelte": "^5.56.0"
+    "svelte": "^5.56.1"
   },
   "peerDependencies": {
     "svelte": "^5.55.9"

--- a/packages/storylite/bin/imported-css-bridge.mjs
+++ b/packages/storylite/bin/imported-css-bridge.mjs
@@ -1,0 +1,109 @@
+import { resolvedVirtualImportedCssId, virtualImportedCssId } from './project-graph.mjs'
+
+const cssRequestRE = /\.(css|less|sass|scss|styl|stylus|pcss|postcss)(?:$|\?)/
+const viteUpdateStyleCall = '__vite__updateStyle(__vite__id, __vite__css)'
+const viteRemoveStylePruneCall = 'import.meta.hot.prune(() => __vite__removeStyle(__vite__id))'
+
+export function storyliteImportedCssBridgePlugin() {
+  return {
+    name: 'storylite-imported-css-bridge',
+    enforce: 'post',
+    resolveId(id) {
+      if (id === virtualImportedCssId) {
+        return resolvedVirtualImportedCssId
+      }
+
+      return null
+    },
+    load(id) {
+      if (id !== resolvedVirtualImportedCssId) {
+        return null
+      }
+
+      return createImportedCssRuntimeCode()
+    },
+    transform(code, id) {
+      if (!cssRequestRE.test(id)) {
+        return null
+      }
+
+      const rewritten = rewriteImportedCssModule(code)
+      return rewritten === code ? null : { code: rewritten, map: null }
+    },
+  }
+}
+
+export function createImportedCssRuntimeCode() {
+  return `function createStoryLiteImportedCssRegistry() {
+  const entries = new Map();
+
+  return {
+    set(id, css) {
+      entries.set(String(id), String(css ?? ''));
+    },
+    delete(id) {
+      entries.delete(String(id));
+    },
+    toArray() {
+      return Array.from(entries.values()).filter(Boolean);
+    },
+  };
+}
+
+const storyliteImportedCssTarget = globalThis.window ?? globalThis;
+
+export const storyliteImportedCss =
+  storyliteImportedCssTarget.__STORYLITE_IMPORTED_CSS__ ??
+  createStoryLiteImportedCssRegistry();
+
+storyliteImportedCssTarget.__STORYLITE_IMPORTED_CSS__ = storyliteImportedCss;
+`
+}
+
+export function rewriteImportedCssModule(code) {
+  if (!code.includes(viteUpdateStyleCall)) {
+    return code
+  }
+
+  const withBridgeHelpers = `${importedCssBridgeHelpers()}\n${code}`
+
+  return withBridgeHelpers
+    .replace(
+      viteUpdateStyleCall,
+      '__storylite_updateImportedCss(__vite__id, __vite__css, __vite__updateStyle)',
+    )
+    .replace(
+      viteRemoveStylePruneCall,
+      'import.meta.hot.prune(() => __storylite_removeImportedCss(__vite__id, __vite__removeStyle))',
+    )
+}
+
+function importedCssBridgeHelpers() {
+  return `function __storylite_importedCssRegistry() {
+  const target = globalThis.window ?? globalThis;
+  return target.__STORYLITE_IMPORTED_CSS__;
+}
+
+function __storylite_updateImportedCss(id, css, fallback) {
+  const registry = __storylite_importedCssRegistry();
+
+  if (registry && typeof registry.set === 'function') {
+    registry.set(id, css);
+    return;
+  }
+
+  fallback(id, css);
+}
+
+function __storylite_removeImportedCss(id, fallback) {
+  const registry = __storylite_importedCssRegistry();
+
+  if (registry && typeof registry.delete === 'function') {
+    registry.delete(id);
+    return;
+  }
+
+  fallback(id);
+}
+`
+}

--- a/packages/storylite/bin/imported-css-bridge.test.mjs
+++ b/packages/storylite/bin/imported-css-bridge.test.mjs
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  createImportedCssRuntimeCode,
-  rewriteImportedCssModule,
-} from '../../../bin/imported-css-bridge.mjs'
+import { createImportedCssRuntimeCode, rewriteImportedCssModule } from './imported-css-bridge.mjs'
 
 describe('storylite imported css bridge', () => {
   it('rewrites vite css style injection to the StoryLite registry', () => {

--- a/packages/storylite/bin/project-graph.mjs
+++ b/packages/storylite/bin/project-graph.mjs
@@ -18,6 +18,7 @@ export const projectModulePath = '/project.js'
 const defaultConfig = { stories: ['./src/**/*.stories.{ts,tsx,js,jsx}'], css: [] }
 const builtinRenderers = new Set(['html', 'web-components'])
 const reservedExports = new Set(['default', '__esModule'])
+const cssFileRE = /\.(css|less|sass|scss|styl|stylus|pcss|postcss)$/
 const conventionFileNames = [
   'manager-head.html',
   'manager-body-start.html',
@@ -540,7 +541,7 @@ function isProjectFile(root, file) {
     normalized.startsWith('.storylite/') ||
     normalized.includes('.stories.') ||
     normalized.endsWith('.md') ||
-    normalized.endsWith('.css') ||
+    cssFileRE.test(normalized) ||
     normalized.endsWith('.html') ||
     normalized.endsWith('.tsx') ||
     normalized.endsWith('.ts')

--- a/packages/storylite/bin/project-graph.mjs
+++ b/packages/storylite/bin/project-graph.mjs
@@ -11,6 +11,8 @@ import { isBareImportSpecifier, isRecord } from '../src/lib/storylite/utils.js'
 
 export const virtualProjectId = 'virtual:storylite/project'
 export const resolvedVirtualProjectId = `\0${virtualProjectId}`
+export const virtualImportedCssId = 'virtual:storylite/imported-css'
+export const resolvedVirtualImportedCssId = `\0${virtualImportedCssId}`
 export const projectModulePath = '/project.js'
 
 const defaultConfig = { stories: ['./src/**/*.stories.{ts,tsx,js,jsx}'], css: [] }
@@ -146,6 +148,14 @@ export async function resolveStoryliteProjectPlugins(
 
 export function generateProjectModuleCode(manifest, options = {}) {
   const useStaticStoryMetadata = options.includeStoryModules === 'metadata'
+  const includeImportedCssRuntime =
+    options.includeImportedCssRuntime ??
+    Boolean(
+      options.serveManager && options.includeStoryModules !== false && !useStaticStoryMetadata,
+    )
+  const importedCssRuntimeImport = includeImportedCssRuntime
+    ? `import { storyliteImportedCss } from ${JSON.stringify(virtualImportedCssId)};`
+    : ''
   const storyImports =
     options.includeStoryModules === false
       ? ''
@@ -189,7 +199,8 @@ export function generateProjectModuleCode(manifest, options = {}) {
   const storySourceMetadata = JSON.stringify(manifest.storySourceMetadataByFile ?? {})
   const isStaticBuild = options.isStaticBuild ?? !options.serveManager
 
-  return `${storyImports}
+  return `${importedCssRuntimeImport}
+${storyImports}
 ${cssImports}
 ${setupImport}
 
@@ -200,6 +211,7 @@ ${storyMap}
 export const storyModuleExportNames = ${storyModuleExportNames};
 export const storySourceMetadata = ${storySourceMetadata};
 export const globalCss = [${cssList}];
+export const importedCss = ${includeImportedCssRuntime ? 'storyliteImportedCss.toArray()' : '[]'};
 export const setupPreview = importedSetupPreview;
 export const storyIdResolver = ${formatFunctionExport(manifest.storyIdResolverSource)};
 export const rendererClientLoaders = {

--- a/packages/storylite/bin/static-build.mjs
+++ b/packages/storylite/bin/static-build.mjs
@@ -16,6 +16,7 @@ import {
 } from '../src/lib/storylite/utils.js'
 
 const reservedExports = new Set(['default', '__esModule'])
+const cssRequestRE = /\.(css|less|sass|scss|styl|stylus|pcss|postcss)(?:$|\?)/
 
 export async function emitManagerShell({ managerDistDir, outDir, manager, app }) {
   await cp(managerDistDir, outDir, { recursive: true })
@@ -64,6 +65,7 @@ export async function emitStaticStoryPages({
     }
 
     const css = await loadCss(server, manifest.cssFiles)
+    const importedCss = await loadImportedStoryCss(server, manifest.storyFiles)
 
     await Promise.all(
       stories.map(async (story) => {
@@ -71,6 +73,7 @@ export async function emitStaticStoryPages({
           story,
           manifest,
           css,
+          importedCss,
           base,
           staticRenderers,
           publicAssetPaths,
@@ -126,10 +129,68 @@ export async function loadCss(server, files) {
   return contents.join('\n\n')
 }
 
+export async function loadImportedStoryCss(server, storyFiles) {
+  return loadCss(server, collectImportedStoryCssFiles(server, storyFiles))
+}
+
+export function collectImportedStoryCssFiles(server, storyFiles) {
+  const cssFiles = new Set()
+  const seenModules = new Set()
+
+  for (const file of storyFiles) {
+    const modules = server.moduleGraph.getModulesByFile(file) ?? []
+
+    for (const module of modules) {
+      collectImportedCssFiles(module, cssFiles, seenModules)
+    }
+  }
+
+  return Array.from(cssFiles)
+}
+
+function collectImportedCssFiles(module, cssFiles, seenModules) {
+  if (!module || seenModules.has(module)) {
+    return
+  }
+
+  seenModules.add(module)
+
+  const cssFile = cssFileForModule(module)
+  if (cssFile) {
+    cssFiles.add(cssFile)
+  }
+
+  for (const importedModule of module.importedModules ?? []) {
+    collectImportedCssFiles(importedModule, cssFiles, seenModules)
+  }
+}
+
+function cssFileForModule(module) {
+  const file = module.file ?? filePathFromModuleId(module.id)
+  return file && cssRequestRE.test(file) ? file : null
+}
+
+function filePathFromModuleId(id) {
+  const path = cleanModuleId(id)
+
+  if (path.startsWith('/@fs/')) {
+    return path.slice('/@fs'.length)
+  }
+
+  return null
+}
+
+function cleanModuleId(id) {
+  return String(id ?? '')
+    .replace(/^\0/, '')
+    .split('?')[0]
+}
+
 async function renderStaticStoryPage(
   story,
   manifest,
   globalCss,
+  importedCss,
   base,
   staticRenderers,
   publicAssetPaths = new Set(),
@@ -173,6 +234,12 @@ async function renderStaticStoryPage(
     base,
     publicAssetFallbackBase,
   )
+  const previewImportedCss = rewritePublicAssetUrls(
+    importedCss,
+    publicAssetPaths,
+    base,
+    publicAssetFallbackBase,
+  )
   const previewSetupScript = staticPreviewSetupScript(
     manifest,
     base,
@@ -193,6 +260,7 @@ async function renderStaticStoryPage(
     <style>
       ${previewBaseCss()}
       ${previewGlobalCss}
+      ${previewImportedCss}
       ${storyCss}
       .sl-static-warning {
         margin: 0 0 1rem;

--- a/packages/storylite/bin/storylite.mjs
+++ b/packages/storylite/bin/storylite.mjs
@@ -6,6 +6,7 @@ import process from 'node:process'
 import { parseArgs } from 'node:util'
 import { createServer, build, preview } from 'vite'
 import { transformBuiltManagerHtml } from './customization.mjs'
+import { storyliteImportedCssBridgePlugin } from './imported-css-bridge.mjs'
 import { isBareImportSpecifier } from '../src/lib/storylite/utils.js'
 import {
   createProjectGraph,
@@ -70,6 +71,7 @@ if (command === 'dev') {
     publicDir: manifest.publicDir,
     plugins: [
       ...vitePlugins,
+      storyliteImportedCssBridgePlugin(),
       storylitePlugin(projectRoot, graph, {
         managerDistDir,
         serveManager: true,

--- a/packages/storylite/package.json
+++ b/packages/storylite/package.json
@@ -67,7 +67,7 @@
     "fast-glob": "^3.3.3",
     "gray-matter": "^4.0.3",
     "marked": "^18.0.4",
-    "vite": "^8.0.14"
+    "vite": "^8.0.16"
   },
   "devDependencies": {
     "@lucide/svelte": "^1.17.0",
@@ -75,8 +75,8 @@
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tsconfig/svelte": "^5.0.8",
     "@types/node": "^25.9.1",
-    "svelte": "^5.56.0",
-    "svelte-check": "^4.4.8",
+    "svelte": "^5.56.1",
+    "svelte-check": "^4.5.0",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/storylite/src/App.svelte
+++ b/packages/storylite/src/App.svelte
@@ -17,6 +17,7 @@
   import {
     globalCss,
     home,
+    importedCss,
     isStaticBuild,
     previewHtml,
     projectUi,
@@ -207,6 +208,7 @@
       {activeArgs}
       {reloadNonce}
       {globalCss}
+      {importedCss}
       {previewHtml}
       {setupPreview}
       {home}

--- a/packages/storylite/src/lib/components/PreviewWorkspace.svelte
+++ b/packages/storylite/src/lib/components/PreviewWorkspace.svelte
@@ -25,6 +25,7 @@
     readonly activeArgs: StoryArgs
     readonly reloadNonce: number
     readonly globalCss: readonly string[]
+    readonly importedCss: readonly string[]
     readonly previewHtml: PreviewHtmlOptions
     readonly setupPreview: ((window: Window) => void) | undefined
     readonly home: HomePage
@@ -41,6 +42,7 @@
     activeArgs,
     reloadNonce,
     globalCss,
+    importedCss,
     previewHtml,
     setupPreview,
     home,
@@ -89,6 +91,7 @@
       theme: storyliteSettings.previewTheme,
       background: storyliteSettings.background,
       globalCss,
+      importedCss,
       html: previewHtml,
       setupPreview,
     }
@@ -158,6 +161,7 @@
       mountedStory = null
       const renderedStory = renderStoryIntoDocument(document, currentCanvas, activeStory, args, {
         globalCss,
+        importedCss,
         setupPreview,
         rendererClientLoaders,
       })

--- a/packages/storylite/src/lib/renderers/runtime.test.ts
+++ b/packages/storylite/src/lib/renderers/runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { applyArgsToElement, renderStoryIntoCanvas } from './runtime'
+import { applyArgsToElement, collectPreviewCss, renderStoryIntoCanvas } from './runtime'
 
 describe('applyArgsToElement', () => {
   it('assigns properties and mirrors primitive values to attributes', () => {
@@ -65,5 +65,35 @@ describe('renderStoryIntoCanvas', () => {
         },
       ),
     ).rejects.toThrow('no matching renderer adapter is registered')
+  })
+})
+
+describe('collectPreviewCss', () => {
+  it('orders configured, imported, and story css', () => {
+    expect(
+      collectPreviewCss(
+        {
+          globalCss: ['.global { color: red; }'],
+          importedCss: ['.imported { color: green; }'],
+        },
+        {
+          id: 'demo--custom',
+          importPath: 'src/demo.stories.ts',
+          exportName: 'Custom',
+          title: 'Demo',
+          name: 'Custom',
+          args: {},
+          argTypes: {},
+          parameters: {
+            css: '.story { color: blue; }',
+          },
+          renderer: 'html',
+        },
+      ),
+    ).toBe(
+      ['.global { color: red; }', '.imported { color: green; }', '.story { color: blue; }'].join(
+        '\n\n',
+      ),
+    )
   })
 })

--- a/packages/storylite/src/lib/renderers/runtime.ts
+++ b/packages/storylite/src/lib/renderers/runtime.ts
@@ -21,6 +21,7 @@ export type PreviewOptions = {
   readonly background: string
   readonly theme: 'light' | 'dark'
   readonly globalCss?: readonly string[]
+  readonly importedCss?: readonly string[]
   readonly html?: PreviewHtmlOptions
   readonly setupPreview?: (window: Window) => void
   readonly rendererClientLoaders?: StoryLiteRendererClientLoaders
@@ -28,6 +29,7 @@ export type PreviewOptions = {
 
 export type CanvasRenderOptions = {
   readonly globalCss?: readonly string[]
+  readonly importedCss?: readonly string[]
   readonly setupPreview?: (window: Window) => void
   readonly rendererClientLoaders?: StoryLiteRendererClientLoaders
 }
@@ -56,7 +58,7 @@ export function preparePreview(
 
   options.setupPreview?.(parts.document.defaultView ?? iframe.contentWindow ?? window)
 
-  const css = [...(options.globalCss ?? []), collectCss(story)].filter(Boolean).join('\n\n')
+  const css = collectPreviewCss(options, story)
   applyBundle(iframe, {
     'tokens.css': previewBaseCss(options),
     'components.css': css,
@@ -94,10 +96,7 @@ export function renderStoryIntoDocument(
 ): Promise<MountedStory> {
   const win = document.defaultView ?? window
   options.setupPreview?.(win)
-  applyInlinePreviewCss(
-    document,
-    [...(options.globalCss ?? []), collectCss(story)].filter(Boolean).join('\n\n'),
-  )
+  applyInlinePreviewCss(document, collectPreviewCss(options, story))
   document.documentElement.dataset.theme = 'light'
 
   return renderStoryIntoCanvas(
@@ -238,6 +237,15 @@ function collectCss(story: StoryLiteStory): string {
   const css = story.parameters.css
 
   return typeof css === 'string' ? css : (css?.join('\n\n') ?? '')
+}
+
+export function collectPreviewCss(
+  options: Pick<PreviewOptions, 'globalCss' | 'importedCss'>,
+  story: StoryLiteStory,
+): string {
+  return [...(options.globalCss ?? []), ...(options.importedCss ?? []), collectCss(story)]
+    .filter(Boolean)
+    .join('\n\n')
 }
 
 function applyInlinePreviewCss(document: Document, css: string): void {

--- a/packages/storylite/src/lib/storylite/imported-css-bridge.test.mjs
+++ b/packages/storylite/src/lib/storylite/imported-css-bridge.test.mjs
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createImportedCssRuntimeCode,
+  rewriteImportedCssModule,
+} from '../../../bin/imported-css-bridge.mjs'
+
+describe('storylite imported css bridge', () => {
+  it('rewrites vite css style injection to the StoryLite registry', () => {
+    const code = [
+      'import { updateStyle as __vite__updateStyle, removeStyle as __vite__removeStyle } from "/@vite/client"',
+      'const __vite__id = "/project/src/button.css"',
+      'const __vite__css = ".button { color: red; }"',
+      '__vite__updateStyle(__vite__id, __vite__css)',
+      'import.meta.hot.accept()',
+      'import.meta.hot.prune(() => __vite__removeStyle(__vite__id))',
+    ].join('\n')
+    const rewritten = rewriteImportedCssModule(code)
+
+    expect(rewritten).toContain('__storylite_updateImportedCss')
+    expect(rewritten).toContain(
+      '__storylite_updateImportedCss(__vite__id, __vite__css, __vite__updateStyle)',
+    )
+    expect(rewritten).toContain(
+      'import.meta.hot.prune(() => __storylite_removeImportedCss(__vite__id, __vite__removeStyle))',
+    )
+    expect(rewritten).not.toContain('__vite__updateStyle(__vite__id, __vite__css)')
+  })
+
+  it('preserves css module exports while redirecting the style side effect', () => {
+    const code = [
+      'import { updateStyle as __vite__updateStyle, removeStyle as __vite__removeStyle } from "/@vite/client"',
+      'const __vite__id = "/project/src/button.module.css"',
+      'const __vite__css = ".button_hash { color: red; }"',
+      '__vite__updateStyle(__vite__id, __vite__css)',
+      'export const button = "button_hash";',
+      'export default { button };',
+      'import.meta.hot.prune(() => __vite__removeStyle(__vite__id))',
+    ].join('\n')
+    const rewritten = rewriteImportedCssModule(code)
+
+    expect(rewritten).toContain('export const button = "button_hash";')
+    expect(rewritten).toContain('export default { button };')
+    expect(rewritten).toContain(
+      '__storylite_updateImportedCss(__vite__id, __vite__css, __vite__updateStyle)',
+    )
+  })
+
+  it('creates a global registry with stable array output', async () => {
+    delete globalThis.__STORYLITE_IMPORTED_CSS__
+
+    const moduleUrl = `data:text/javascript,${encodeURIComponent(createImportedCssRuntimeCode())}`
+    const module = await import(moduleUrl)
+
+    module.storyliteImportedCss.set('one.css', '.one {}')
+    module.storyliteImportedCss.set('two.css', '.two {}')
+    module.storyliteImportedCss.delete('one.css')
+
+    expect(module.storyliteImportedCss.toArray()).toEqual(['.two {}'])
+  })
+})

--- a/packages/storylite/src/lib/storylite/project-graph.test.mjs
+++ b/packages/storylite/src/lib/storylite/project-graph.test.mjs
@@ -12,6 +12,7 @@ import {
   resolvePublicDir,
   resolveStoryliteProjectPlugins,
   storyPagePath,
+  virtualImportedCssId,
 } from '../../../bin/project-graph.mjs'
 
 describe('storylite project graph', () => {
@@ -446,6 +447,31 @@ export const Card = {}`,
       await server.close()
       await rm(root, { force: true, recursive: true })
     }
+  })
+
+  it('imports the css runtime before story modules in dev mode', () => {
+    const manifest = {
+      projectRoot: '/project',
+      storyFiles: ['/project/src/button.stories.ts'],
+      cssFiles: [],
+      publicDir: false,
+      setupFile: null,
+      rendererAdapters: [],
+      storyExportNamesByFile: {},
+      storySourceMetadataByFile: {},
+      storyIdResolverSource: null,
+      ui: {},
+      preview: {},
+      manager: {},
+      home: null,
+    }
+    const moduleCode = generateProjectModuleCode(manifest, { serveManager: true })
+    const cssRuntimeImport = `import { storyliteImportedCss } from ${JSON.stringify(virtualImportedCssId)};`
+    const storyImport = 'import * as storyModule0 from "/@fs/project/src/button.stories.ts";'
+
+    expect(moduleCode.indexOf(cssRuntimeImport)).toBeGreaterThanOrEqual(0)
+    expect(moduleCode.indexOf(cssRuntimeImport)).toBeLessThan(moduleCode.indexOf(storyImport))
+    expect(moduleCode).toContain('export const importedCss = storyliteImportedCss.toArray();')
   })
 
   it('rejects renderer adapters that override built-in renderers', async () => {

--- a/packages/storylite/src/lib/storylite/project-graph.test.mjs
+++ b/packages/storylite/src/lib/storylite/project-graph.test.mjs
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { createServer } from 'vite'
 import { describe, expect, it } from 'vitest'
 import {
+  createProjectGraph,
   extractStoryExportNames,
   extractStorySourceMetadata,
   generateProjectModuleCode,
@@ -16,6 +17,15 @@ import {
 } from '../../../bin/project-graph.mjs'
 
 describe('storylite project graph', () => {
+  it('treats css preprocessor files as project files for reloads', () => {
+    const graph = createProjectGraph('/project')
+
+    expect(graph.isProjectFile('/project/src/button.css')).toBe(true)
+    expect(graph.isProjectFile('/project/src/button.scss')).toBe(true)
+    expect(graph.isProjectFile('/project/src/button.less')).toBe(true)
+    expect(graph.isProjectFile('/project/src/button.styl')).toBe(true)
+  })
+
   it('extracts story export names in source order', async () => {
     expect(
       await extractStoryExportNames(

--- a/packages/storylite/src/lib/storylite/static-build.test.mjs
+++ b/packages/storylite/src/lib/storylite/static-build.test.mjs
@@ -1,10 +1,12 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createServer } from 'vite'
 import { describe, expect, it } from 'vitest'
 import {
+  collectImportedStoryCssFiles,
   emitManagerShell,
+  loadImportedStoryCss,
   loadCss,
   rewritePublicAssetUrls,
   staticPreviewSetupScript,
@@ -121,6 +123,78 @@ describe('storylite static build', () => {
 
     try {
       await expect(loadCss(server, [cssFile])).resolves.toContain('color: transformed')
+    } finally {
+      await server.close()
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it('loads css imported through story modules for static pages', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'storylite-static-imported-css-'))
+    const srcDir = join(root, 'src')
+    await mkdir(srcDir)
+
+    const storyFile = join(srcDir, 'button.stories.ts')
+    const componentFile = join(srcDir, 'button.ts')
+    const cssFile = join(srcDir, 'button.css')
+
+    await writeFile(
+      storyFile,
+      `
+        import { renderButton } from './button'
+
+        export default { title: 'Demo' }
+        export const Button = { render: renderButton }
+      `,
+    )
+    await writeFile(
+      componentFile,
+      `
+        import './button.css'
+
+        export function renderButton() {
+          return '<button class="imported-button">Save</button>'
+        }
+      `,
+    )
+    await writeFile(cssFile, '.imported-button { color: __TOKEN__; }')
+
+    const server = await createServer({
+      configFile: false,
+      root,
+      appType: 'custom',
+      plugins: [
+        {
+          name: 'test-static-imported-css-transform',
+          transform(code, id) {
+            if (id.includes('button.css')) {
+              return code.replace('__TOKEN__', 'transformed')
+            }
+
+            return null
+          },
+        },
+      ],
+      server: {
+        middlewareMode: true,
+        hmr: false,
+        ws: false,
+      },
+      optimizeDeps: {
+        entries: [],
+        noDiscovery: true,
+      },
+    })
+
+    try {
+      await server.ssrLoadModule(`/@fs${storyFile}`)
+
+      await expect(realpath(cssFile)).resolves.toBe(
+        collectImportedStoryCssFiles(server, [storyFile])[0],
+      )
+      await expect(loadImportedStoryCss(server, [storyFile])).resolves.toContain(
+        'color: transformed',
+      )
     } finally {
       await server.close()
       await rm(root, { force: true, recursive: true })

--- a/packages/storylite/src/story-modules.ts
+++ b/packages/storylite/src/story-modules.ts
@@ -1,6 +1,7 @@
 import {
   globalCss,
   home,
+  importedCss,
   isStaticBuild,
   managerHtml,
   previewHtml,
@@ -26,6 +27,7 @@ export const storyIdCollisions = normalizedStories.idCollisions
 export {
   globalCss,
   home,
+  importedCss,
   isStaticBuild,
   managerHtml,
   previewHtml,

--- a/packages/storylite/src/vite-env.d.ts
+++ b/packages/storylite/src/vite-env.d.ts
@@ -61,6 +61,7 @@ declare module 'virtual:storylite/project' {
   export const storyModuleExportNames: Record<string, readonly string[]>
   export const storySourceMetadata: StorySourceMetadataByImportPath
   export const globalCss: readonly string[]
+  export const importedCss: readonly string[]
   export const setupPreview: ((window: Window) => void) | undefined
   export const storyIdResolver: StoryIdResolver | undefined
   export const rendererClientLoaders: Record<string, () => Promise<StoryLiteClientRendererModule>>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     devDependencies:
       oxfmt:
-        specifier: ^0.52.0
-        version: 0.52.0(svelte@5.56.0)
+        specifier: ^0.53.0
+        version: 0.53.0(svelte@5.56.1)
       publint:
         specifier: ^0.3.21
         version: 0.3.21
@@ -24,8 +24,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   apps/e2e:
     devDependencies:
@@ -39,8 +39,8 @@ importers:
         specifier: ^25.9.1
         version: 25.9.1
       '@vitest/browser-playwright':
-        specifier: ^4.1.7
-        version: 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))(vitest@4.1.7)
+        specifier: ^4.1.8
+        version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))(vitest@4.1.8)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -58,8 +58,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   demos/storylite-html:
     dependencies:
@@ -71,14 +71,14 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   demos/storylite-preact:
     dependencies:
       '@preact/preset-vite':
         specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.29.7)(preact@10.29.2)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 2.10.5(@babel/core@7.29.7)(preact@10.29.2)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       '@storylite/renderer-preact':
         specifier: workspace:*
         version: link:../../packages/renderer-preact
@@ -94,7 +94,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -102,8 +102,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   demos/storylite-react:
     dependencies:
@@ -114,21 +114,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/storylite
       react:
-        specifier: ^19.2.6
-        version: 19.2.6
+        specifier: ^19.2.7
+        version: 19.2.7
       react-dom:
-        specifier: ^19.2.6
-        version: 19.2.6(react@19.2.6)
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       '@types/react':
-        specifier: ^19.2.15
-        version: 19.2.15
+        specifier: ^19.2.16
+        version: 19.2.16
       '@types/react-dom':
         specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.15)
+        version: 19.2.3(@types/react@19.2.16)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -136,8 +136,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   demos/storylite-solid:
     dependencies:
@@ -152,11 +152,11 @@ importers:
         version: 1.9.13
       vite-plugin-solid:
         specifier: 2.11.12
-        version: 2.11.12(solid-js@1.9.13)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 2.11.12(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -164,8 +164,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   demos/storylite-svelte:
     dependencies:
@@ -176,18 +176,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/storylite
       svelte:
-        specifier: ^5.56.0
-        version: 5.56.0
+        specifier: ^5.56.1
+        version: 5.56.1
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.56.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 7.1.2(svelte@5.56.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       svelte-check:
-        specifier: ^4.4.8
-        version: 4.4.8(picomatch@4.0.4)(svelte@5.56.0)(typescript@6.0.3)
+        specifier: ^4.5.0
+        version: 4.5.0(picomatch@4.0.4)(svelte@5.56.1)(typescript@6.0.3)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -195,8 +195,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   demos/storylite-vue:
     dependencies:
@@ -208,7 +208,7 @@ importers:
         version: link:../../packages/storylite
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))(vue@3.5.35(typescript@6.0.3))
+        version: 6.0.7(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))(vue@3.5.35(typescript@6.0.3))
       '@vue/server-renderer':
         specifier: ^3.5.35
         version: 3.5.35(vue@3.5.35(typescript@6.0.3))
@@ -218,7 +218,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -226,8 +226,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
-        specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   packages/contracts: {}
 
@@ -241,7 +241,7 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.29.7)(preact@10.29.2)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 2.10.5(@babel/core@7.29.7)(preact@10.29.2)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -259,17 +259,17 @@ importers:
         version: link:../contracts
     devDependencies:
       '@types/react':
-        specifier: ^19.2.15
-        version: 19.2.15
+        specifier: ^19.2.16
+        version: 19.2.16
       '@types/react-dom':
         specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.15)
+        version: 19.2.3(@types/react@19.2.16)
       react:
-        specifier: ^19.2.6
-        version: 19.2.6
+        specifier: ^19.2.7
+        version: 19.2.7
       react-dom:
-        specifier: ^19.2.6
-        version: 19.2.6(react@19.2.6)
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
 
   packages/renderer-solid:
     dependencies:
@@ -285,7 +285,7 @@ importers:
         version: 1.9.13
       vite-plugin-solid:
         specifier: 2.11.12
-        version: 2.11.12(solid-js@1.9.13)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 2.11.12(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   packages/renderer-svelte:
     dependencies:
@@ -294,11 +294,11 @@ importers:
         version: link:../contracts
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.56.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 7.1.2(svelte@5.56.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
     devDependencies:
       svelte:
-        specifier: ^5.56.0
-        version: 5.56.0
+        specifier: ^5.56.1
+        version: 5.56.1
 
   packages/renderer-vue:
     dependencies:
@@ -308,7 +308,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))(vue@3.5.35(typescript@6.0.3))
+        version: 6.0.7(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))(vue@3.5.35(typescript@6.0.3))
       '@vue/server-renderer':
         specifier: ^3.5.35
         version: 3.5.35(vue@3.5.35(typescript@6.0.3))
@@ -334,18 +334,18 @@ importers:
         specifier: ^18.0.4
         version: 18.0.4
       vite:
-        specifier: ^8.0.14
-        version: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
     devDependencies:
       '@lucide/svelte':
         specifier: ^1.17.0
-        version: 1.17.0(svelte@5.56.0)
+        version: 1.17.0(svelte@5.56.1)
       '@storylite/preview-host':
         specifier: workspace:*
         version: link:../preview-host
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.56.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+        version: 7.1.2(svelte@5.56.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       '@tsconfig/svelte':
         specifier: ^5.0.8
         version: 5.0.8
@@ -353,11 +353,11 @@ importers:
         specifier: ^25.9.1
         version: 25.9.1
       svelte:
-        specifier: ^5.56.0
-        version: 5.56.0
+        specifier: ^5.56.1
+        version: 5.56.1
       svelte-check:
-        specifier: ^4.4.8
-        version: 4.4.8(picomatch@4.0.4)(svelte@5.56.0)(typescript@6.0.3)
+        specifier: ^4.5.0
+        version: 4.5.0(picomatch@4.0.4)(svelte@5.56.1)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -538,130 +538,127 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oxc-project/types@0.132.0':
-    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
-
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
-  '@oxfmt/binding-android-arm-eabi@0.52.0':
-    resolution: {integrity: sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ==}
+  '@oxfmt/binding-android-arm-eabi@0.53.0':
+    resolution: {integrity: sha512-XfVM8AmIovBTKXCt14Op5wbfcoM8418nttd+nhMgM3RAVaJg1MtJc73FyWfUt0oxLyBGVwfniNVUsbV/b3VmPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.52.0':
-    resolution: {integrity: sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ==}
+  '@oxfmt/binding-android-arm64@0.53.0':
+    resolution: {integrity: sha512-btHDfXckwdf9zgyAVznfZkf+GVyB0I1m1hlvaOMRx2xoyz3hphfPX97s89J3wfCN8QBETLtk4lQUaeOkrMuQOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.52.0':
-    resolution: {integrity: sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA==}
+  '@oxfmt/binding-darwin-arm64@0.53.0':
+    resolution: {integrity: sha512-k2RjMcSTkHjoOlsVGbL35JVzXL+oQco3GHPl/5kjebVF4oHNfE24In8F5isqBh9LBJucycWHKDXdGrCchdWcHQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.52.0':
-    resolution: {integrity: sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw==}
+  '@oxfmt/binding-darwin-x64@0.53.0':
+    resolution: {integrity: sha512-65jIBE2H1l5SSs16fmv6/7b6sAx/WpvnsgDhVWK9qSjNFDUro7MPQ6q5UhpY7kl46yltfR046iAnxy/Bzqbiew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.52.0':
-    resolution: {integrity: sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA==}
+  '@oxfmt/binding-freebsd-x64@0.53.0':
+    resolution: {integrity: sha512-oYe1gkz7U49PCYrS9147d2fJZj8mDI4Di6AvlsU5fu9p+Tq8S7qqOMSZjUiVTLX8bXuSA9Lk/tIxuegVjkNYRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.52.0':
-    resolution: {integrity: sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.53.0':
+    resolution: {integrity: sha512-ailB2vLzGi629tymdAb2VYJyEHref7oqGxP+tRBrtRBxQrb6NV55JMT7xtGZ8uTeG2+Y9zojqW4LhJYxQnz9Pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.52.0':
-    resolution: {integrity: sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.53.0':
+    resolution: {integrity: sha512-abh4mWBvOvD966sobqF7r103y2yYx7Rb4WGHLOS4+5igGqLbbPxS9aK5+45D6iUY7dWMsk3Muz9a8gUtufvqJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.52.0':
-    resolution: {integrity: sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw==}
+  '@oxfmt/binding-linux-arm64-gnu@0.53.0':
+    resolution: {integrity: sha512-z73PvuhJ8qA+cDbaiqbtopHglA91U4+y5wn2sTJJrnpB957d5P33FEuyP3DQIFd7ofljmDmfVT4G0CVGHZaJWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.52.0':
-    resolution: {integrity: sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg==}
+  '@oxfmt/binding-linux-arm64-musl@0.53.0':
+    resolution: {integrity: sha512-I6bhOTroqc3ThrwZ89l2k3ivKuELhdPLbAcJhRNyjWvlgwb0vjRgEnVL1XLx5Jud04/ypNRZBykAWrSk6l/D+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
-    resolution: {integrity: sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.53.0':
+    resolution: {integrity: sha512-w0p3JzB/PkkQjXALMJMqP9YfP3yq4w6zGsu5kezQmUnxRkN3b/Theg2l/nDgBsOcczxS3gL6Gam5XNAVrO6QJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
-    resolution: {integrity: sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.53.0':
+    resolution: {integrity: sha512-mzBhF6k1Yq1K/dqDmVe/AAafnlJfEpx7yfUiksyeWXJk5iSzZqBSxcsa02zIytYgQFRZ7h6WPZfwHg/DoOE1Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.52.0':
-    resolution: {integrity: sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw==}
+  '@oxfmt/binding-linux-riscv64-musl@0.53.0':
+    resolution: {integrity: sha512-AlFCpnRQhogQFzZXWbO6xB6/Udy745L+eQNmDPGg7G/OeWsYmJc4jZYfUN5pQg0reOPWSED2mOQqKZOJM1U8cA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.52.0':
-    resolution: {integrity: sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg==}
+  '@oxfmt/binding-linux-s390x-gnu@0.53.0':
+    resolution: {integrity: sha512-XD4ulY4f1DWbuuZXAqxhVn+gdPmrhnmojWtFN78ctVoupmS845fGhsUrk1HZXKQI+iymbaiz9vAjPsghHNQ7Ag==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.52.0':
-    resolution: {integrity: sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA==}
+  '@oxfmt/binding-linux-x64-gnu@0.53.0':
+    resolution: {integrity: sha512-xg8KWX0QnxmYWRe60CgHYWXI0ZOtBbqTsXvWiWrcl2XUHJ3fht2QerOk2iWvylzX3zNT2GpvBRxGoR4d3sxPRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.52.0':
-    resolution: {integrity: sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw==}
+  '@oxfmt/binding-linux-x64-musl@0.53.0':
+    resolution: {integrity: sha512-MWExpYBGvl+pIvVB/gj/CcWlN2al8AizT7rUbtaYaWNoQkhWARM6W3qpgoCr72CYSN9PborzPmM5MIRe2BrNdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.52.0':
-    resolution: {integrity: sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ==}
+  '@oxfmt/binding-openharmony-arm64@0.53.0':
+    resolution: {integrity: sha512-u4sajgO4nxgmJIgc/y2AqPhkdbOkQH8WugXpA1+pW0ESQhvGZ1oGq61Q4xMbJHJU1hFgtO18QNrcFYDPYH0gwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.52.0':
-    resolution: {integrity: sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ==}
+  '@oxfmt/binding-win32-arm64-msvc@0.53.0':
+    resolution: {integrity: sha512-Yq9sOZoIOJ5xPjO0qOyHJS4CiPuTkB2en9auxZz7Ar2p5RaC7BzLyVVmAA7zz9/L9YnjjY1DwNxN+ivKXimN/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.52.0':
-    resolution: {integrity: sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ==}
+  '@oxfmt/binding-win32-ia32-msvc@0.53.0':
+    resolution: {integrity: sha512-es1fVNZEkBqEcQtBpn19SYFgZF7FawlkCjkT/iImfEAus4gun8fBwB1E9hpV5LcR9B0DBNvRIXhW8BQk3JaE+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.52.0':
-    resolution: {integrity: sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw==}
+  '@oxfmt/binding-win32-x64-msvc@0.53.0':
+    resolution: {integrity: sha512-QFmJs2bEu9AO4O6qsmEaZNGi6dFq8N+rT8EHAAnZIq/B9SeJDUbc4DzVxQ48MfDsL7D3sCZzo37zuTuspcURgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -704,34 +701,16 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@rolldown/binding-android-arm64@1.0.2':
-    resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.2':
-    resolution: {integrity: sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.0.3':
     resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.2':
-    resolution: {integrity: sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.3':
@@ -740,36 +719,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.2':
-    resolution: {integrity: sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.0.3':
     resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
-    resolution: {integrity: sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
     resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.2':
-    resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
@@ -778,13 +738,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.2':
-    resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -792,24 +745,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
-    resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.2':
-    resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -820,26 +759,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.2':
-    resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rolldown/binding-linux-x64-musl@1.0.2':
-    resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
@@ -848,44 +773,21 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.2':
-    resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.2':
-    resolution: {integrity: sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.3':
     resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.2':
-    resolution: {integrity: sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
     resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.0.2':
-    resolution: {integrity: sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.3':
@@ -1057,8 +959,8 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react@19.2.15':
-    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+  '@types/react@19.2.16':
+    resolution: {integrity: sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1070,22 +972,22 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/browser-playwright@4.1.7':
-    resolution: {integrity: sha512-OlTlJej7YN6VwV7zJJoNeaCsctF+JXpzpZ4oBHUbrQFfIq+0KW2f07rprCLh9N/zRIZ0v4Mchn1QDDmWMUhPKw==}
+  '@vitest/browser-playwright@4.1.8':
+    resolution: {integrity: sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.1.7
+      vitest: 4.1.8
 
-  '@vitest/browser@4.1.7':
-    resolution: {integrity: sha512-N2JFGfXoEGVAut+kHeru9dD4BUMq/q5xDvBARNl0tUsly3m5KglLOu8VO/6MkDfOlgxXTycojkt6gBKsuyR+IQ==}
+  '@vitest/browser@4.1.8':
+    resolution: {integrity: sha512-u21VzX07HzlJYpFgkxmjEXar/tG2UqWGgyGG/46SrrPc7rSdCTPw5vuowopO9CIqF8UCUQzDFdbVnNpw6N0BfQ==}
     peerDependencies:
-      vitest: 4.1.7
+      vitest: 4.1.8
 
-  '@vitest/expect@4.1.7':
-    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@4.1.7':
-    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1095,20 +997,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.7':
-    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@4.1.7':
-    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@4.1.7':
-    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@4.1.7':
-    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/utils@4.1.7':
-    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@vue/compiler-core@3.5.35':
     resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
@@ -1144,8 +1046,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ansis@4.3.0:
-    resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
+  ansis@4.3.1:
+    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
   argparse@1.0.10:
@@ -1190,8 +1092,8 @@ packages:
       solid-js:
         optional: true
 
-  baseline-browser-mapping@2.10.32:
-    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+  baseline-browser-mapping@2.10.33:
+    resolution: {integrity: sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1287,8 +1189,8 @@ packages:
       oxc-resolver:
         optional: true
 
-  electron-to-chromium@1.5.364:
-    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
+  electron-to-chromium@1.5.365:
+    resolution: {integrity: sha512-xfip4u1QF1s+URFqpA6N+OeFpDGpN7VJz1f3MO3bVL0QYBjpGiZ5/Of7kugvM+o8TTqmanUlviHN3c8M9vYWCw==}
 
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
@@ -1580,8 +1482,8 @@ packages:
   node-html-parser@6.1.13:
     resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
-  node-releases@2.0.46:
-    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+  node-releases@2.0.47:
+    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
   nth-check@2.1.1:
@@ -1590,8 +1492,8 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  oxfmt@0.52.0:
-    resolution: {integrity: sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug==}
+  oxfmt@0.53.0:
+    resolution: {integrity: sha512-9cB5glS3Ip6NMuZ+6NYTao9FCWkDhRtPYCtR3QBu/NxHoFbgzzTvi41N4jxz/GqGfuLKspui1qb/LlSu2IbMcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1660,13 +1562,13 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-dom@19.2.6:
-    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: ^19.2.6
+      react: ^19.2.7
 
-  react@19.2.6:
-    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   readdirp@5.0.0:
@@ -1698,11 +1600,6 @@ packages:
         optional: true
       vue-tsc:
         optional: true
-
-  rolldown@1.0.2:
-    resolution: {integrity: sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
 
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
@@ -1785,16 +1682,16 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
-  svelte-check@4.4.8:
-    resolution: {integrity: sha512-67adfgBox5eNSNIvIIwgFizKGdcRrGpiMoNO2obHcYuLz7iTa8Xgm/NGU3ntMFnNm8K1grFOIG6HhMLX/vcN8w==}
+  svelte-check@4.5.0:
+    resolution: {integrity: sha512-9lNwPxCLWniFvQIcEv1LFqjIxcFtO3smb5+5BKbRJ3ttL4o2lXCej5rLF4DAnfLPI66oaA81vAxw6ILdIWI7kA==}
     engines: {node: '>= 18.0.0'}
     hasBin: true
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
-  svelte@5.56.0:
-    resolution: {integrity: sha512-kTXr26t1bchFp28ROrb957LtbujpBmBDibmqMGziVpUs7awBi96TGgX6SovrA8BNoEUDVRK2Fb9FkeYlGspoVg==}
+  svelte@5.56.1:
+    resolution: {integrity: sha512-eArsJmvl3xZVuTYD852PzIEdg2wgDdIZ1NEsIPbzAukHwi284B18No4nK2rCO9AwsWUDza4Cjvmoa4HaojTl5g==}
     engines: {node: '>=18'}
 
   tailwindcss@4.3.0:
@@ -1807,12 +1704,12 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.2.3:
-    resolution: {integrity: sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==}
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinypool@2.1.0:
@@ -1904,8 +1801,8 @@ packages:
     peerDependencies:
       vite: 5.x || 6.x || 7.x || 8.x
 
-  vite@8.0.14:
-    resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1955,20 +1852,20 @@ packages:
       vite:
         optional: true
 
-  vitest@4.1.7:
-    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.7
-      '@vitest/browser-preview': 4.1.7
-      '@vitest/browser-webdriverio': 4.1.7
-      '@vitest/coverage-istanbul': 4.1.7
-      '@vitest/coverage-v8': 4.1.7
-      '@vitest/ui': 4.1.7
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2226,9 +2123,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lucide/svelte@1.17.0(svelte@5.56.0)':
+  '@lucide/svelte@1.17.0(svelte@5.56.1)':
     dependencies:
-      svelte: 5.56.0
+      svelte: 5.56.1
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -2249,65 +2146,63 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@oxc-project/types@0.132.0': {}
-
   '@oxc-project/types@0.133.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.52.0':
+  '@oxfmt/binding-android-arm-eabi@0.53.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.52.0':
+  '@oxfmt/binding-android-arm64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.52.0':
+  '@oxfmt/binding-darwin-arm64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.52.0':
+  '@oxfmt/binding-darwin-x64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.52.0':
+  '@oxfmt/binding-freebsd-x64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.52.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.52.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.52.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.52.0':
+  '@oxfmt/binding-linux-arm64-musl@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.52.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.52.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.52.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.52.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.52.0':
+  '@oxfmt/binding-linux-x64-gnu@0.53.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.52.0':
+  '@oxfmt/binding-linux-x64-musl@0.53.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.52.0':
+  '@oxfmt/binding-openharmony-arm64@0.53.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.52.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.53.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.52.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.53.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.52.0':
+  '@oxfmt/binding-win32-x64-msvc@0.53.0':
     optional: true
 
   '@playwright/test@1.60.0':
@@ -2316,19 +2211,19 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.29.7)(preact@10.29.2)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.7)(preact@10.29.2)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-development': 7.29.7(@babel/core@7.29.7)
-      '@prefresh/vite': 2.4.12(preact@10.29.2)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+      '@prefresh/vite': 2.4.12(preact@10.29.2)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       '@rollup/pluginutils': 5.4.0
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.7)
       debug: 4.4.3
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
-      vite-prerender-plugin: 0.5.13(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
+      vite-prerender-plugin: 0.5.13(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - preact
@@ -2343,7 +2238,7 @@ snapshots:
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.29.2)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))':
+  '@prefresh/vite@2.4.12(preact@10.29.2)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@prefresh/babel-plugin': 0.5.3
@@ -2351,7 +2246,7 @@ snapshots:
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
       preact: 10.29.2
-      vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2361,83 +2256,40 @@ snapshots:
     dependencies:
       quansync: 1.0.0
 
-  '@rolldown/binding-android-arm64@1.0.2':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.3':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.2':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.2':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.0.3':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.2':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.2':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.2':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.2':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.0.3':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.2':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.2':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.2':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.2':
-    optional: true
-
   '@rolldown/binding-openharmony-arm64@1.0.3':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.2':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.3':
@@ -2447,13 +2299,7 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.2':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.2':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.3':
@@ -2478,14 +2324,14 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.1)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.56.0
-      vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
-      vitefu: 1.1.3(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+      svelte: 5.56.1
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
+      vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
 
   '@tailwindcss/node@4.3.0':
     dependencies:
@@ -2548,12 +2394,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
 
   '@tsconfig/svelte@5.0.8': {}
 
@@ -2598,45 +2444,45 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
-  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+  '@types/react-dom@19.2.3(@types/react@19.2.16)':
     dependencies:
-      '@types/react': 19.2.15
+      '@types/react': 19.2.16
 
-  '@types/react@19.2.15':
+  '@types/react@19.2.16':
     dependencies:
       csstype: 3.2.3
 
   '@types/trusted-types@2.0.7': {}
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))(vue@3.5.35(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))(vue@3.5.35(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
       vue: 3.5.35(typescript@6.0.3)
 
-  '@vitest/browser-playwright@4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))(vitest@4.1.7)':
+  '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))(vitest@4.1.8)':
     dependencies:
-      '@vitest/browser': 4.1.7(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))(vitest@4.1.7)
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+      vitest: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.7(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))(vitest@4.1.7)':
+  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))(vitest@4.1.8)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
-      '@vitest/utils': 4.1.7
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+      vitest: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -2644,44 +2490,44 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/expect@4.1.7':
+  '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))':
     dependencies:
-      '@vitest/spy': 4.1.7
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
 
-  '@vitest/pretty-format@4.1.7':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.7':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 4.1.7
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.7':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.7': {}
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/utils@4.1.7':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.7
+      '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -2741,7 +2587,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  ansis@4.3.0: {}
+  ansis@4.3.1: {}
 
   argparse@1.0.10:
     dependencies:
@@ -2781,7 +2627,7 @@ snapshots:
     optionalDependencies:
       solid-js: 1.9.13
 
-  baseline-browser-mapping@2.10.32: {}
+  baseline-browser-mapping@2.10.33: {}
 
   birpc@4.0.0: {}
 
@@ -2793,10 +2639,10 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.32
+      baseline-browser-mapping: 2.10.33
       caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.364
-      node-releases: 2.0.46
+      electron-to-chromium: 1.5.365
+      node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   cac@7.0.0: {}
@@ -2857,7 +2703,7 @@ snapshots:
 
   dts-resolver@3.0.0: {}
 
-  electron-to-chromium@1.5.364: {}
+  electron-to-chromium@1.5.365: {}
 
   empathic@2.0.1: {}
 
@@ -3067,7 +2913,7 @@ snapshots:
       css-select: 5.2.2
       he: 1.2.0
 
-  node-releases@2.0.46: {}
+  node-releases@2.0.47: {}
 
   nth-check@2.1.1:
     dependencies:
@@ -3075,30 +2921,30 @@ snapshots:
 
   obug@2.1.1: {}
 
-  oxfmt@0.52.0(svelte@5.56.0):
+  oxfmt@0.53.0(svelte@5.56.1):
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.52.0
-      '@oxfmt/binding-android-arm64': 0.52.0
-      '@oxfmt/binding-darwin-arm64': 0.52.0
-      '@oxfmt/binding-darwin-x64': 0.52.0
-      '@oxfmt/binding-freebsd-x64': 0.52.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.52.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.52.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.52.0
-      '@oxfmt/binding-linux-arm64-musl': 0.52.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.52.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.52.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.52.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.52.0
-      '@oxfmt/binding-linux-x64-gnu': 0.52.0
-      '@oxfmt/binding-linux-x64-musl': 0.52.0
-      '@oxfmt/binding-openharmony-arm64': 0.52.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.52.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.52.0
-      '@oxfmt/binding-win32-x64-msvc': 0.52.0
-      svelte: 5.56.0
+      '@oxfmt/binding-android-arm-eabi': 0.53.0
+      '@oxfmt/binding-android-arm64': 0.53.0
+      '@oxfmt/binding-darwin-arm64': 0.53.0
+      '@oxfmt/binding-darwin-x64': 0.53.0
+      '@oxfmt/binding-freebsd-x64': 0.53.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.53.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.53.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.53.0
+      '@oxfmt/binding-linux-arm64-musl': 0.53.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.53.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.53.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.53.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.53.0
+      '@oxfmt/binding-linux-x64-gnu': 0.53.0
+      '@oxfmt/binding-linux-x64-musl': 0.53.0
+      '@oxfmt/binding-openharmony-arm64': 0.53.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.53.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.53.0
+      '@oxfmt/binding-win32-x64-msvc': 0.53.0
+      svelte: 5.56.1
 
   package-manager-detector@1.6.0: {}
 
@@ -3147,12 +2993,12 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-dom@19.2.6(react@19.2.6):
+  react-dom@19.2.7(react@19.2.7):
     dependencies:
-      react: 19.2.6
+      react: 19.2.7
       scheduler: 0.27.0
 
-  react@19.2.6: {}
+  react@19.2.7: {}
 
   readdirp@5.0.0: {}
 
@@ -3175,27 +3021,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
-
-  rolldown@1.0.2:
-    dependencies:
-      '@oxc-project/types': 0.132.0
-      '@rolldown/pluginutils': 1.0.1
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.2
-      '@rolldown/binding-darwin-arm64': 1.0.2
-      '@rolldown/binding-darwin-x64': 1.0.2
-      '@rolldown/binding-freebsd-x64': 1.0.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.2
-      '@rolldown/binding-linux-arm64-gnu': 1.0.2
-      '@rolldown/binding-linux-arm64-musl': 1.0.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.2
-      '@rolldown/binding-linux-s390x-gnu': 1.0.2
-      '@rolldown/binding-linux-x64-gnu': 1.0.2
-      '@rolldown/binding-linux-x64-musl': 1.0.2
-      '@rolldown/binding-openharmony-arm64': 1.0.2
-      '@rolldown/binding-wasm32-wasi': 1.0.2
-      '@rolldown/binding-win32-arm64-msvc': 1.0.2
-      '@rolldown/binding-win32-x64-msvc': 1.0.2
 
   rolldown@1.0.3:
     dependencies:
@@ -3284,19 +3109,19 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
-  svelte-check@4.4.8(picomatch@4.0.4)(svelte@5.56.0)(typescript@6.0.3):
+  svelte-check@4.5.0(picomatch@4.0.4)(svelte@5.56.1)(typescript@6.0.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 5.0.0
       fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.56.0
+      svelte: 5.56.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte@5.56.0:
+  svelte@5.56.1:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3323,9 +3148,9 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.2.3: {}
+  tinyexec@1.2.4: {}
 
-  tinyglobby@0.2.16:
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -3344,7 +3169,7 @@ snapshots:
 
   tsdown@0.22.1(publint@0.3.21)(typescript@6.0.3):
     dependencies:
-      ansis: 4.3.0
+      ansis: 4.3.1
       cac: 7.0.0
       defu: 6.1.7
       empathic: 2.0.1
@@ -3355,8 +3180,8 @@ snapshots:
       rolldown: 1.0.3
       rolldown-plugin-dts: 0.25.2(rolldown@1.0.3)(typescript@6.0.3)
       semver: 7.8.1
-      tinyexec: 1.2.3
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
     optionalDependencies:
@@ -3386,7 +3211,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite-plugin-solid@2.11.12(solid-js@1.9.13)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)):
+  vite-plugin-solid@2.11.12(solid-js@1.9.13)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.7
       '@types/babel__core': 7.20.5
@@ -3394,12 +3219,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.13
       solid-refresh: 0.6.3(solid-js@1.9.13)
-      vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
-      vitefu: 1.1.3(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
+      vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite-prerender-plugin@0.5.13(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)):
+  vite-prerender-plugin@0.5.13(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)):
     dependencies:
       kolorist: 1.8.0
       magic-string: 0.30.21
@@ -3407,33 +3232,33 @@ snapshots:
       simple-code-frame: 1.3.0
       source-map: 0.7.6
       stack-trace: 1.0.0
-      vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
 
-  vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0):
+  vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.15
-      rolldown: 1.0.2
-      tinyglobby: 0.2.16
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitefu@1.1.3(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)):
+  vitefu@1.1.3(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)):
     optionalDependencies:
-      vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
 
-  vitest@4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)):
+  vitest@4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)):
     dependencies:
-      '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/runner': 4.1.7
-      '@vitest/snapshot': 4.1.7
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -3442,14 +3267,14 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.2.3
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.14(@types/node@25.9.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@25.9.1)(jiti@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
-      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0))(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## Summary

Fixes #80.

This updates StoryLite so CSS imported by story/component modules is applied to the preview document instead of leaking into the manager UI.

- Adds an internal imported-CSS bridge for Vite dev CSS modules.
- Registers imported story CSS before story modules load.
- Applies preview CSS in this order: global config CSS, imported story CSS, story `parameters.css`.
- Includes imported story CSS in static story pages by collecting CSS dependencies from Vite’s module graph and loading them with `?inline`.
- Adds vanilla HTML and React demo stories that verify component/module CSS imports style the preview only.
- Treats CSS preprocessor files as project files for reloads.
- Moves the imported CSS bridge test next to the bridge implementation.
- Adds a dedicated Playwright E2E CI job with Chromium install, browser cache, GitHub annotations, HTML report artifacts, and job summary output.
- Refreshes workspace dependencies.

## Testing

For testing the changes in consumer projects, please check our [CONTRIBUTING.md guidelines](https://github.com/itsjavi/storylite/blob/main/CONTRIBUTING.md) in order to build and use local tarballs.